### PR TITLE
Update purescript dependencies and tests

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-uuid",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "moduleType": [
     "node"
   ],
@@ -15,10 +15,10 @@
     "url": "git://github.com/spicydonuts/purescript-uuid.git"
   },
   "dependencies": {
-    "purescript-eff": "~0.1.2"
+    "purescript-eff": "^1.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^0.1.0",
-    "purescript-spec": "~0.7.2"
+    "purescript-console": "^1.0.0",
+    "purescript-spec": "~0.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "uuid": "^2.0.1",
+    "uuid": "^2.0.3",
     "uuid-validate": "0.0.2"
   },
   "devDependencies": {

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,27 +1,25 @@
 module Test.Main where
 
 import Prelude
-import Control.Monad.Eff
-import Control.Monad.Eff.Console
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Class (liftEff)
+import Control.Monad.Eff.Console (CONSOLE)
+import Data.Maybe (Maybe(..), fromJust)
+import Data.String (length)
+import Data.UUID (parseUUID, genUUID, GENUUID)
+import Node.Process (PROCESS)
+import Partial.Unsafe (unsafePartial)
+import Test.Spec (it, describe)
+import Test.Spec.Assertions (shouldEqual)
+import Test.Spec.Reporter.Console (consoleReporter)
+import Test.Spec.Runner (run)
 
-import Control.Monad.Aff
-
-import Data.Maybe
-import Data.Maybe.Unsafe
-import Data.String
-import Data.UUID
-
-import Test.Spec
-import Test.Spec.Assertions
-import Test.Spec.Runner
-import Test.Spec.Reporter.Console
-
-main :: forall e. Eff (uuid :: GENUUID, console :: CONSOLE, process :: Process | e) Unit
-main = run [consoleReporter] do
+main :: forall e. Eff (uuid :: GENUUID, console :: CONSOLE, process :: PROCESS | e) Unit
+main = unsafePartial $ run [consoleReporter] do
   describe "Data.UUID" do
     it "`genUUID` returns a uuid" do
-      uuid <- liftEff' genUUID
-      (length <<< show) uuid `shouldEqual` 44
+      uuid <- liftEff genUUID
+      (length <<< show) uuid `shouldEqual` 36
 
     it "`parseUUID` parses a valid uuid as Just UUID" do
       let uuidStr = "d0778cf2-3a4c-42ef-acbd-1269b6bec204"


### PR DESCRIPTION
This pull request updates the bower dependencies to use purescript-prelude v1.0.0 (as v2.0.0 is not yet widely supported). I also fixed the tests to work with psc v0.9.3.
