### PR TITLE
Bump uuid from 3.4.0 to 8.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 [![Build Status](https://travis-ci.org/spicydonuts/purescript-uuid.svg?branch=master)](https://travis-ci.org/spicydonuts/purescript-uuid)
 
-Wrapper for the `uuid` and `uuid-validate` npm packages.
-These packages are not installed automatically, as they come from `npm`.
-Install them with `npm install -S uuid uuid-validate`.
+Wrapper for the `uuid` npm package.
+This package are not installed automatically, as it comes from `npm`.
+Install it with `npm install -S uuid`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2532,6 +2532,14 @@
         "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "resolve": {
@@ -3334,14 +3342,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-    },
-    "uuid-validate": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/uuid-validate/-/uuid-validate-0.0.3.tgz",
-      "integrity": "sha512-Fykw5U4eZESbq739BeLvEBFRuJODfrlmjx5eJux7W817LjRaq4b7/i4t2zxQmhcX+fAj4nMfRdTzO4tmwLKn0w=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,12 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/spicydonuts/purescript-uuid"
+  },
   "dependencies": {
-    "uuid": "^3.4.0",
-    "uuid-validate": "0.0.3"
+    "uuid": "^8.3.0"
   },
   "devDependencies": {
     "bower": "^1.8.8",

--- a/src/Data/UUID.js
+++ b/src/Data/UUID.js
@@ -5,27 +5,39 @@
 var mkV3UUID = null;
 exports.getUUID3Impl = function (str) {
   return function (namespace) {
-    if (mkV3UUID === null) mkV3UUID = require('uuid/v3');
+    if (mkV3UUID === null) {
+      var uuid = require('uuid');
+      mkV3UUID = uuid.v3;
+    }
     return mkV3UUID(str, namespace);
   };
 };
 
 var mkV4UUID = null;
 exports.getUUIDImpl = function () {
-  if (mkV4UUID === null) mkV4UUID = require('uuid/v4');
+  if (mkV4UUID === null) {
+    var uuid = require('uuid');
+    mkV4UUID = uuid.v4;
+  }
   return mkV4UUID();
 };
 
 var mkV5UUID = null;
 exports.getUUID5Impl = function (str) {
   return function (namespace) {
-    if (mkV5UUID === null) mkV5UUID = require('uuid/v5');
+    if (mkV5UUID === null) {
+      var uuid = require('uuid');
+      mkV5UUID = uuid.v5;
+    }
     return mkV5UUID(str, namespace);
   };
 };
 
-var validateV4UUID = null;
+var validateUUID = null;
 exports.validateV4UUID = function (str) {
-  if (validateV4UUID === null) validateV4UUID = require('uuid-validate');
-  return validateV4UUID(str, 4);
+  if (validateUUID === null) {
+    var uuid = require('uuid');
+    validateUUID = uuid.validate;
+  }
+  return validateUUID(str);
 };


### PR DESCRIPTION
This bump removes a DeprecationWarning emitted by the new `uuid` npm package. To do so, a little bit of code from the wrapper have to be changed, as the npm package now expose the multiple UUID versions through named exports (on ESM) and object keys (on CJS).

As the new version of the `uuid` npm package also include a validation feature, this pull requests rely on it directly, removing the need for `uuid-validate` (which is a nice side-effect!).

Closes #16.