### PR TITLE
Import uuid library using module object syntax

### DIFF
--- a/src/Data/UUID.js
+++ b/src/Data/UUID.js
@@ -1,18 +1,18 @@
 // module Data.UUID
-import { v3, v4, v5, validate } from "uuid";
+import uuid from "uuid";
 
 export const getUUID3Impl = function (str) {
   return function (namespace) {
-    return v3(str, namespace);
+    return uuid.v3(str, namespace);
   };
 };
 
-export const getUUIDImpl = v4;
+export const getUUIDImpl = uuid.v4;
 
 export const getUUID5Impl = function (str) {
   return function (namespace) {
-    return v5(str, namespace);
+    return uuid.v5(str, namespace);
   };
 };
 
-export const validateV4UUID = validate;
+export const validateV4UUID = uuid.validate;


### PR DESCRIPTION
Using `import { ... } from "uuid";` caused an error for Affresco when I tried to run it, using `import uuid from "uuid";` syntax worked better. I'm afraid I lack the expertise at JS to give an explanation why this works and the one currently in master doesn't.